### PR TITLE
resolves #45: double-click on cell crashes focal

### DIFF
--- a/src/week-view.c
+++ b/src/week-view.c
@@ -570,26 +570,6 @@ void week_view_add_calendar(WeekView* wv, Calendar* cal)
 	gtk_widget_queue_draw((GtkWidget*) wv);
 }
 
-struct tm week_view_get_day_start(WeekView* wv)
-{
-	time_t timestamp = wv->current_view.start;
-	struct tm local;
-
-	localtime_r(&timestamp, &local);
-
-	return local;
-}
-
-int week_view_get_week(WeekView* wv)
-{
-	return wv->current_week;
-}
-
-int week_view_get_year(WeekView* wv)
-{
-	return wv->current_year;
-}
-
 static int weeks_in_year(int year)
 {
 	int jan1_dow = icaltime_day_of_week(icaltime_from_day_of_year(1, year));

--- a/src/week-view.c
+++ b/src/week-view.c
@@ -284,9 +284,9 @@ static gboolean on_press_event(GtkWidget* widget, GdkEventButton* event, gpointe
 
 	} else if (event->type == GDK_2BUTTON_PRESS) {
 		// double-click: request to create an event
-		if (NULL == wv->calendars) {
+		if (wv->calendars == NULL) {
 			// TODO report error (no calendar configured) via UI. TBD: ask whether to open accounts configuration
-			return FALSE;
+			return TRUE;
 		}
 
 		time_t at = wv->current_view.start + dow * 24 * 3600;
@@ -568,6 +568,11 @@ void week_view_add_calendar(WeekView* wv, Calendar* cal)
 	wv->calendars = g_slist_append(wv->calendars, cal);
 	calendar_each_event(cal, add_event_from_calendar, wv);
 	gtk_widget_queue_draw((GtkWidget*) wv);
+}
+
+int week_view_get_current_week(WeekView* wv)
+{
+	return wv->current_week;
 }
 
 static int weeks_in_year(int year)

--- a/src/week-view.c
+++ b/src/week-view.c
@@ -284,6 +284,11 @@ static gboolean on_press_event(GtkWidget* widget, GdkEventButton* event, gpointe
 
 	} else if (event->type == GDK_2BUTTON_PRESS) {
 		// double-click: request to create an event
+		if (NULL == wv->calendars) {
+			// TODO report error (no calendar configured) via UI. TBD: ask whether to open accounts configuration
+			return FALSE;
+		}
+
 		time_t at = wv->current_view.start + dow * 24 * 3600;
 		icaltimetype dtstart, dtend;
 
@@ -565,9 +570,24 @@ void week_view_add_calendar(WeekView* wv, Calendar* cal)
 	gtk_widget_queue_draw((GtkWidget*) wv);
 }
 
-int week_view_get_current_week(WeekView* wv)
+struct tm week_view_get_day_start(WeekView* wv)
+{
+	time_t timestamp = wv->current_view.start;
+	struct tm local;
+
+	localtime_r(&timestamp, &local);
+
+	return local;
+}
+
+int week_view_get_week(WeekView* wv)
 {
 	return wv->current_week;
+}
+
+int week_view_get_year(WeekView* wv)
+{
+	return wv->current_year;
 }
 
 static int weeks_in_year(int year)


### PR DESCRIPTION
Prevent crash by adding into event's click handler: detect no calendar being configured, abort handling than. Added TODO: enhance handling after deciding how to proceed