### PR TITLE
resolves #53: Highlight today

### DIFF
--- a/src/ics-calendar.c
+++ b/src/ics-calendar.c
@@ -131,7 +131,7 @@ static void stream_read_done(GObject* source, GAsyncResult* res, gpointer user_d
 	long bytes_read = g_input_stream_read_finish(G_INPUT_STREAM(source), res, &err);
 	if (bytes_read < 0) {
 		// error
-		g_critical(err->message);
+		g_critical("%s", err->message);
 		// TODO: cleanup leaks
 		return;
 	}
@@ -160,7 +160,7 @@ static void file_read_done(GObject* source, GAsyncResult* res, gpointer user_dat
 	GError* err = NULL;
 	GFileInputStream* stream = g_file_read_finish(G_FILE(source), res, &err);
 	if (err) {
-		g_critical(err->message);
+		g_critical("%s", err->message);
 		return;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -281,8 +281,6 @@ static void focal_create_main_window(GApplication* app, FocalApp* fm)
 {
 	fm->mainWindow = gtk_application_window_new(GTK_APPLICATION(app));
 
-	allocate_colors();
-	init_style(fm->mainWindow);
 	fm->weekView = week_view_new();
 	week_view_set_day_span(FOCAL_WEEK_VIEW(fm->weekView), fm->prefs.week_start_day, fm->prefs.week_end_day);
 	fm->eventDetail = g_object_new(FOCAL_TYPE_EVENT_PANEL, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -280,6 +280,9 @@ static void workaround_sync_event_detail_with_week_view(GtkWidget* event_panel, 
 static void focal_create_main_window(GApplication* app, FocalApp* fm)
 {
 	fm->mainWindow = gtk_application_window_new(GTK_APPLICATION(app));
+
+	allocate_colors();
+	init_style(fm->mainWindow);
 	fm->weekView = week_view_new();
 	week_view_set_day_span(FOCAL_WEEK_VIEW(fm->weekView), fm->prefs.week_start_day, fm->prefs.week_end_day);
 	fm->eventDetail = g_object_new(FOCAL_TYPE_EVENT_PANEL, NULL);

--- a/src/week-view.h
+++ b/src/week-view.h
@@ -21,9 +21,6 @@
 #define FOCAL_TYPE_WEEK_VIEW (week_view_get_type())
 G_DECLARE_FINAL_TYPE(WeekView, week_view, FOCAL, WEEK_VIEW, GtkDrawingArea)
 
-void allocate_colors(void);
-void init_style(GtkWidget *mainWindow);
-
 GtkWidget* week_view_new(void);
 
 void week_view_add_event(WeekView* wv, Event* vevent);

--- a/src/week-view.h
+++ b/src/week-view.h
@@ -21,6 +21,9 @@
 #define FOCAL_TYPE_WEEK_VIEW (week_view_get_type())
 G_DECLARE_FINAL_TYPE(WeekView, week_view, FOCAL, WEEK_VIEW, GtkDrawingArea)
 
+void allocate_colors(void);
+void init_style(GtkWidget *mainWindow);
+
 GtkWidget* week_view_new(void);
 
 void week_view_add_event(WeekView* wv, Event* vevent);


### PR DESCRIPTION
this PR additionally contains the following visual suggestions:
-naming colors by their intended use instead of their color, makes it more intuitive/easier to understand and work on code for ui rendering.
-less variation of color contrast and font sizes should make the overall ui appearance more usable and harmonic.
-to highlight the current day i used a light blue color, roughly following the jetbrains darcula theme. Until having support for themes, i recommend defining a color theme to follow as a basic style guide. 
