### PR TITLE
cmake: fix minor copy-paste error, don't need 2x libxml2 definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ add_definitions(${LIBXML2_DEFINITIONS})
 # cURL
 find_package(CURL REQUIRED)
 include_directories(${CURL_INCLUDE_DIRS})
-add_definitions(${LIBXML2_DEFINITIONS})
+add_definitions(${CURL_DEFINITIONS})
 
 # libical
 pkg_check_modules(ICAL REQUIRED libical)


### PR DESCRIPTION
Change to add curl definitions, should any be needed.
Not sure if CURL_DEFINITIONS is set by anything, however.