### PR TITLE
caldav: Handle gracefully components containing no VEVENT's

### DIFF
--- a/src/caldav-calendar.c
+++ b/src/caldav-calendar.c
@@ -398,7 +398,7 @@ static Event* create_event_from_parsed_xml(CaldavCalendar* cal, CaldavEntry* cde
 	if (!vev) {
 		icalcomponent_free(comp);
 		return NULL;
-	};
+	}
 	Event* ev = event_new_from_icalcomponent(vev);
 	event_set_calendar(ev, FOCAL_CALENDAR(cal));
 	event_set_url(ev, cde->href);

--- a/src/caldav-calendar.c
+++ b/src/caldav-calendar.c
@@ -395,8 +395,10 @@ static Event* create_event_from_parsed_xml(CaldavCalendar* cal, CaldavEntry* cde
 	// event updated
 	icalcomponent* comp = icalparser_parse_string(cde->caldata);
 	icalcomponent* vev = icalcomponent_get_first_component(comp, ICAL_VEVENT_COMPONENT);
-	if (!vev)
+	if (!vev) {
+		icalcomponent_free(comp);
 		return NULL;
+	};
 	Event* ev = event_new_from_icalcomponent(vev);
 	event_set_calendar(ev, FOCAL_CALENDAR(cal));
 	event_set_url(ev, cde->href);


### PR DESCRIPTION
Currently such a resource causes an assertion failure,
effectively preventing use with such calendars entirely.

With this change, focal "gracefully" handles these by
ignoring them and moving along.