### PR TITLE
event-popup,app-header: tooltips to help explain what buttons do

### DIFF
--- a/src/app-header.c
+++ b/src/app-header.c
@@ -134,6 +134,9 @@ void app_header_init(AppHeader* ah)
 	g_signal_connect_swapped(prev, "clicked", (GCallback) &app_header_nav_prev, ah);
 	g_signal_connect_swapped(ah->btn_current, "clicked", (GCallback) &app_header_nav_current, ah);
 	g_signal_connect_swapped(ah->btn_next, "clicked", (GCallback) &app_header_nav_next, ah);
+	gtk_widget_set_tooltip_text(prev, "Previous week");
+	gtk_widget_set_tooltip_text(ah->btn_current, "Show today");
+	gtk_widget_set_tooltip_text(ah->btn_next, "Next week");
 
 	ah->btn_menu = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(ah->btn_menu), gtk_image_new_from_icon_name("open-menu-symbolic", GTK_ICON_SIZE_MENU));
@@ -149,16 +152,19 @@ void app_header_init(AppHeader* ah)
 	gtk_button_set_image(GTK_BUTTON(ah->btn_sync), ah->icon_sync);
 	g_signal_connect_swapped(ah->btn_sync, "clicked", (GCallback) &app_header_sync, ah);
 	gtk_header_bar_pack_end(GTK_HEADER_BAR(ah), ah->btn_sync);
+	gtk_widget_set_tooltip_text(ah->btn_sync, "Synchronize");
 
 	ah->btn_delete = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(ah->btn_delete), gtk_image_new_from_icon_name("edit-delete-symbolic", GTK_ICON_SIZE_SMALL_TOOLBAR));
 	g_signal_connect_swapped(ah->btn_delete, "clicked", (GCallback) &app_header_delete, ah);
 	gtk_header_bar_pack_end(GTK_HEADER_BAR(ah), ah->btn_delete);
+	gtk_widget_set_tooltip_text(ah->btn_delete, "Delete");
 
 	ah->btn_save = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(ah->btn_save), gtk_image_new_from_icon_name("document-save-symbolic", GTK_ICON_SIZE_SMALL_TOOLBAR));
 	g_signal_connect_swapped(ah->btn_save, "clicked", (GCallback) &app_header_save, ah);
 	gtk_header_bar_pack_end(GTK_HEADER_BAR(ah), ah->btn_save);
+	gtk_widget_set_tooltip_text(ah->btn_save, "Save");
 
 	gtk_header_bar_pack_start(GTK_HEADER_BAR(ah), nav);
 }

--- a/src/event-popup.c
+++ b/src/event-popup.c
@@ -117,31 +117,37 @@ static void event_popup_init(EventPopup* e)
 	btn = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(btn), gtk_image_new_from_icon_name("emblem-ok-symbolic", GTK_ICON_SIZE_SMALL_TOOLBAR));
 	g_signal_connect(btn, "clicked", (GCallback) &rsvp_yes_clicked, e);
+	gtk_widget_set_tooltip_text(btn, "Attending");
 	gtk_action_bar_pack_start(GTK_ACTION_BAR(actions), btn);
 
 	btn = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(btn), gtk_image_new_from_icon_name("dialog-question-symbolic", GTK_ICON_SIZE_SMALL_TOOLBAR));
 	g_signal_connect(btn, "clicked", (GCallback) &rsvp_maybe_clicked, e);
+	gtk_widget_set_tooltip_text(btn, "Tentative");
 	gtk_action_bar_pack_start(GTK_ACTION_BAR(actions), btn);
 
 	btn = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(btn), gtk_image_new_from_icon_name("dialog-error-symbolic", GTK_ICON_SIZE_SMALL_TOOLBAR));
 	g_signal_connect(btn, "clicked", (GCallback) &rsvp_no_clicked, e);
+	gtk_widget_set_tooltip_text(btn, "Decline");
 	gtk_action_bar_pack_start(GTK_ACTION_BAR(actions), btn);
 
 	e->btn_delete = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(e->btn_delete), gtk_image_new_from_icon_name("edit-delete-symbolic", GTK_ICON_SIZE_SMALL_TOOLBAR));
 	g_signal_connect(e->btn_delete, "clicked", (GCallback) &delete_clicked, e);
+	gtk_widget_set_tooltip_text(e->btn_delete, "Delete");
 	gtk_action_bar_pack_end(GTK_ACTION_BAR(actions), e->btn_delete);
 
 	e->btn_save = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(e->btn_save), gtk_image_new_from_icon_name("document-save-symbolic", GTK_ICON_SIZE_SMALL_TOOLBAR));
 	g_signal_connect(e->btn_save, "clicked", (GCallback) &save_clicked, e);
+	gtk_widget_set_tooltip_text(e->btn_save, "Save");
 	gtk_action_bar_pack_end(GTK_ACTION_BAR(actions), e->btn_save);
 
 	btn = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(btn), gtk_image_new_from_icon_name("view-more-horizontal-symbolic", GTK_ICON_SIZE_SMALL_TOOLBAR));
 	g_signal_connect(btn, "clicked", (GCallback) &open_details, e);
+	gtk_widget_set_tooltip_text(btn, "Details...");
 	gtk_action_bar_pack_end(GTK_ACTION_BAR(actions), btn);
 
 	gtk_box_pack_start(GTK_BOX(box), bar, FALSE, FALSE, 0);


### PR DESCRIPTION
Icons are often insufficient for describing a button's purpose
which is especially important for accessibility needs and
for helping beyond a symbolic icon.

Tweaks to text welcome, but text included is hopefully reasonable :).